### PR TITLE
Run uvicorn server with auto-reload

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -14,6 +14,9 @@ from app.core.config import settings
 from plugins.auth.models import User
 from plugins.auth.jwt import verify_token
 
+# Import database session functions directly to avoid circular imports
+from app.db.session import get_db_sync, get_session
+
 # OAuth2 scheme for token authentication
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
 
@@ -112,8 +115,5 @@ def get_current_user_optional_sync(
         return get_current_user_sync(token, db)
     except HTTPException:
         return None
-
-# Import database session functions directly to avoid circular imports
-from app.db.session import get_db_sync, get_session
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,4 @@ fastapi-limiter>=0.1.6
 fastapi-jwt-auth>=0.5.0
 fastapi-security>=0.5.0
 fastapi-pagination>=0.12.17
+httpx>=0.27.0


### PR DESCRIPTION
Fix plugin loading errors by resolving import order for `get_session` and adding `httpx` dependency.

The `name 'get_session' is not defined` error occurred because `get_session` was imported at the bottom of `app/core/auth.py`, making it unavailable to other modules that imported `app.core.auth` earlier during plugin initialization. Moving the import to the top ensures it's defined when needed. The `httpx` dependency was added to resolve a `No module named 'httpx'` error preventing the payments plugin from loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bae471a-5b64-4ba3-8890-1df4ccdba251">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bae471a-5b64-4ba3-8890-1df4ccdba251">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

